### PR TITLE
added instructions for unit test ready setups in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,22 @@
 * For setting up [Jasmine](https://jasmine.github.io/) I've used following [yo jasmine generator](https://github.com/yeoman/generator-jasmine#readme)
 * For setting up [Karma](https://karma-runner.github.io/2.0/index.html) I've used following [yo karma generator](https://github.com/yeoman/generator-karma#readme)
 
-## Jasmine unit tests
-* Configuration file for the HTML runner can be found [here](unit-tests/karma-jasmine_in_chrome/index.html)
+## Jasmine ES6 in-browser unit tests - ready setup
+* Copy the whole directory [unit-tests/karma-jasmine_in_chrome](https://github.com/ionutpetrache/frontend-guild-testing-e2e/tree/master/unit-tests/karma-jasmine_in_chrome).
+* Get into the directory and execute `npm install`.
+* Load [index.html](https://github.com/ionutpetrache/frontend-guild-testing-e2e/blob/master/unit-tests/karma-jasmine_in_chrome/index.html) in the browser and verify that _all but one_ sample tests run successfully.
+* Import your code and start writing your own tests.
+
+## Mocha ES6 in-browser unit tests - ready setup
+* Copy the whole directory [unit-tests/requirejs_es6_in-browser](https://github.com/ionutpetrache/frontend-guild-testing-e2e/tree/master/unit-tests/requirejs_es6_in-browser).
+* Load [Mocha_test_page.html](https://github.com/ionutpetrache/frontend-guild-testing-e2e/blob/master/unit-tests/requirejs_es6_in-browser/Mocha_test_page.html) in the browser and verify that the sample test runs successfully.
+* Import your code and start writing your own tests.
+
+## Mocha ES6 server-side unit tests - ready setup
+* Copy the whole directory [unit_tests/es6_in-server](https://github.com/ionutpetrache/frontend-guild-testing-e2e/tree/master/unit-tests/es6_in-server).
+* Get into the directory and execute `npm install`.
+* Execute 'npm run run_es6_tests' and verify that the sample test runs successfully.
+* Import your code and start writing your own tests.
 
 ## Coverage report with Karma and Istanbul
 1. Run the unit test example with coverage:


### PR DESCRIPTION
I have put clear instructions in the README, that our colleagues can use at the next meeting for getting started with writing unit tests.